### PR TITLE
[Case_Sensitive] - Fix for name and alternate_identity_name query

### DIFF
--- a/lib/ofac/models/ofac.rb
+++ b/lib/ofac/models/ofac.rb
@@ -143,8 +143,8 @@ class Ofac
 
       name_array.delete_if{|n| n.strip.size < 2}
       unless name_array.empty?
-        sql_name_partial = name_array.collect {|partial_name| ["name like ?", "%#{partial_name}%"]}
-        sql_alt_name_partial = name_array.collect {|partial_name| ["alternate_identity_name like ?", "%#{partial_name}%"]}
+        sql_name_partial = name_array.collect {|partial_name| ["lower(name) like ?", "%#{partial_name.downcase}%"]}
+        sql_alt_name_partial = name_array.collect {|partial_name| ["lower(alternate_identity_name) like ?", "%#{partial_name.downcase}%"]}
         conditions = sql_name_partial + sql_alt_name_partial
         conditions = conditions.transpose
         conditions = [conditions.first.join(' or ')] + conditions.second


### PR DESCRIPTION
Hi Kevin,

First of all thanks for this wonderful gem of yours. I am enjoying working with it. 

As, I was working on it. I found a minor flaw in the query to select name and alternate_identity_name which took in my concern when a positive SDN user got passed through the score calculation.

Further looking into the files, I found out that query missed the "ilike or lower" while fetching records. As I am not sure that why you missed this, but was this intentional?

Thanks,
Pratik
