### PR TITLE
Fix parsing and mysql import

### DIFF
--- a/lib/ofac/models/ofac_sdn_loader.rb
+++ b/lib/ofac/models/ofac_sdn_loader.rb
@@ -319,7 +319,7 @@ class OfacSdnLoader
     yield "Deleting all records in ofac_sdn..." if block_given?
 
     #OFAC data is a complete list, so we have to dump and load
-    OfacSdn.delete_all
+    OfacSdn.connection.execute("TRUNCATE ofac_sdns;")
 
     puts "Importing into Mysql..."
     yield "Importing into Mysql..." if block_given?


### PR DESCRIPTION
Fixed several bugs with parsing — failure to strip `\r`; `split` not dealing with empty columns at the end of a line; mysql not actually accepting an empty string for an autoinc field; etc.
