### PR TITLE
Added check to see if ofac_sdns exists before dropping the table

### DIFF
--- a/db/migrate/20140715173240_drop_ofac_sdns.rb
+++ b/db/migrate/20140715173240_drop_ofac_sdns.rb
@@ -1,5 +1,5 @@
 class DropOfacSdns < ActiveRecord::Migration
   def change
-    drop_table :ofac_sdns
+    drop_table :ofac_sdns if ActiveRecord::Base.connection.table_exists? 'ofac_sdns'
   end
 end


### PR DESCRIPTION
For new installations of this gem, the ofac_sdns table doesn't exist. (I assume the drop is in there from an earlier version of the gem, or perhaps your own local installation?) As a result, the migration fails as part of the installation process. This check prevents the drop if the table doesn't exist in the first place.
