### PR TITLE
Add mysql rescue for loading data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 nbproject
 *.idea
 atlassian-ide-plugin.xml
+test/dummy/log/*

--- a/app/models/ofac_sdn_individual_loader.rb
+++ b/app/models/ofac_sdn_individual_loader.rb
@@ -46,9 +46,18 @@ class OfacSdnIndividualLoader
         yield status if block_given?
       end
 
-      bulk_mysql_update(csv_file) do |status|
-        yield status if block_given?
+      begin
+        bulk_mysql_update(csv_file) do |status|
+          yield status if block_given?
+        end
+      rescue ActiveRecord::StatementInvalid
+        sdn.rewind # due to this being read as a side effect of `convert_to_flattened_csv`
+
+        active_record_file_load(sdn, address, alt) do |status|
+          yield status if block_given?
+        end
       end
+
     else
       active_record_file_load(sdn, address, alt) do |status|
         yield status if block_given?


### PR DESCRIPTION
[closes #11]

This will allow most users to proceed without opening a potential security hole at the cost of a slower import.